### PR TITLE
fix ios macos browser error

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,12 +25,12 @@
     <title>[beta]Startup Weekend Map for Japan</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.65.0/build/stlite.min.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.73.0/build/stlite.min.css"
     />
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.65.0/build/stlite.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.73.0/build/stlite.min.js"></script>
     <script>
       // 設定：参照先のGoogleスプレッドシートIDとそれぞれGID
       let sheet_id = '1aImknpImJYyDBYcBAbwA0WIck4hmoH1rorRjJftjlj8'


### PR DESCRIPTION
close #21 

issueにて確認済みですが、stlite本体で起こっているエラーがあり、すでに修正されているので、比較的新しいバージョンmountable@0.73.0 への更新をします。