### PR TITLE
workflow: GitHub Actionsの設定を更新し、依存関係のバージョンを最新にしました

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,16 +3,29 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -25,14 +38,11 @@ jobs:
           cp ogimage.png public/
           cp -r assets public/
       - name: Deploy to GitHub Pages
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: public
   deploy:
     needs: build
-    permissions:
-      pages: write
-      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -40,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
close #34 

---

This pull request updates the GitHub Actions workflow for deploying to GitHub Pages, introducing new configuration options and upgrading action versions to improve functionality and compatibility.

### Workflow Enhancements:
* Added `workflow_dispatch` to enable manual triggering of the workflow.
* Introduced `permissions` and `concurrency` settings to enhance security and manage concurrent deployments.

### Action Version Upgrades:
* Upgraded `actions/checkout` from v2 to v4 for better performance and features.
* Upgraded `actions/setup-python` from v2 to v4 to ensure compatibility with the latest Python setup features.
* Upgraded `actions/upload-pages-artifact` from v1 to v3 to leverage improvements in artifact handling.
* Upgraded `actions/deploy-pages` from v1 to v4 for enhanced deployment capabilities.

### New Steps:
* Added a new step to set up GitHub Pages using `actions/configure-pages@v5`.