### PR TITLE
Issue30 filter evettype main or pre

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -66,11 +66,11 @@ if csv_path.exists():
         organizers = data["主催者"].dropna().unique().tolist()
         selectlist_organizer: list = ["全て"] + organizers
 
-        # 選択済みの開催形式を取得
-        query_params_format = "全て"
-        if "format" in url_params:
-            query_params_format = url_params["format"]
-        selectlist_format: list = ["全て", "オンライン", "物理開催"]
+        # 選択済みのイベント種類を取得
+        query_params_event_type = "全て"
+        if "event_type" in url_params:
+            query_params_event_type = url_params["event_type"]
+        selectlist_event_type: list = ["全て", "本イベント", "プレイベント"]
 
         # 横並びにするためのカラムを作成
         col1, col2 = st.columns(2)
@@ -85,11 +85,11 @@ if csv_path.exists():
             )
 
         with col2:
-            selected_format = st.selectbox(
-                "開催形式",
-                selectlist_format,
-                index=selectlist_format.index(query_params_format)
-                if query_params_format in selectlist_format
+            selected_event_type = st.selectbox(
+                "イベント種類",
+                selectlist_event_type,
+                index=selectlist_event_type.index(query_params_event_type)
+                if query_params_event_type in selectlist_event_type
                 else 0,
             )
 
@@ -103,19 +103,19 @@ if csv_path.exists():
             if "organizer" in st.query_params:
                 del st.query_params["organizer"]
 
-        # 開催形式が選択された場合
-        if selected_format == "オンライン":
-            # 住所が空の場合をオンラインと判定
-            data = data[data["住所"].fillna("").str.strip() == ""]
-            st.query_params["format"] = "オンライン"
-        elif selected_format == "物理開催":
-            # 住所がある場合を物理開催と判定
-            data = data[data["住所"].fillna("").str.strip() != ""]
-            st.query_params["format"] = "物理開催"
+        # イベント種類が選択された場合
+        if selected_event_type == "本イベント":
+            # イベント種類が本イベントの場合
+            data = data[data["イベント種類"] == "本イベント"]
+            st.query_params["event_type"] = "本イベント"
+        elif selected_event_type == "プレイベント":
+            # イベント種類がプレイベントの場合
+            data = data[data["イベント種類"] == "プレイベント"]
+            st.query_params["event_type"] = "プレイベント"
         else:
-            # 開催形式が全ての場合はパラメーターを削除
-            if "format" in st.query_params:
-                del st.query_params["format"]
+            # イベント種類が全ての場合はパラメーターを削除
+            if "event_type" in st.query_params:
+                del st.query_params["event_type"]
 
         # イベントの数が0の場合はメッセージを表示
         if len(data) == 0:
@@ -137,6 +137,7 @@ if csv_path.exists():
         url_column = data.columns[6]  # URL列
         address_column = data.columns[7]  # 住所列
         organizer_column = data.columns[8]  # 主催者列
+        event_type_column = data.columns[9]  # イベント種類列
 
         # 日付列を日本向け表記変換
         data[start_date_column] = pd.to_datetime(data[start_date_column]).dt.tz_convert(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -70,7 +70,7 @@ if csv_path.exists():
         query_params_event_type = "全て"
         if "event_type" in url_params:
             query_params_event_type = url_params["event_type"]
-        selectlist_event_type: list = ["全て", "本イベント", "プレイベント"]
+        selectlist_event_type: list = ["全て", "本イベント", "その他"]
 
         # 横並びにするためのカラムを作成
         col1, col2 = st.columns(2)
@@ -108,10 +108,10 @@ if csv_path.exists():
             # イベント種類が本イベントの場合
             data = data[data["イベント種類"] == "本イベント"]
             st.query_params["event_type"] = "本イベント"
-        elif selected_event_type == "プレイベント":
-            # イベント種類がプレイベントの場合
-            data = data[data["イベント種類"] == "プレイベント"]
-            st.query_params["event_type"] = "プレイベント"
+        elif selected_event_type == "その他":
+            # イベント種類がその他の場合
+            data = data[data["イベント種類"] == "その他"]
+            st.query_params["event_type"] = "その他"
         else:
             # イベント種類が全ての場合はパラメーターを削除
             if "event_type" in st.query_params:

--- a/update_sw_eventlist.py
+++ b/update_sw_eventlist.py
@@ -770,18 +770,27 @@ class StartupWeekendEventCollector:
         """開催日時からイベント種類を判定"""
         try:
             if not start_date or not end_date:
-                return "本イベント"  # デフォルト
+                return "その他"  # デフォルト
 
             # 日付部分のみを比較
             start_date_only = start_date[:10]  # YYYY-MM-DD
             end_date_only = end_date[:10]  # YYYY-MM-DD
 
-            if start_date_only == end_date_only:
-                return "プレイベント"  # 同日開催
+            # 日付をdatetimeオブジェクトに変換
+            from datetime import datetime
+
+            start_dt = datetime.fromisoformat(start_date_only)
+            end_dt = datetime.fromisoformat(end_date_only)
+
+            # 日数を計算（終了日 - 開始日 + 1）
+            duration_days = (end_dt - start_dt).days + 1
+
+            if duration_days == 3:
+                return "本イベント"  # 3日間開催
             else:
-                return "本イベント"  # 複数日開催
+                return "その他"  # 3日間以外
         except Exception:
-            return "本イベント"  # エラー時はデフォルト
+            return "その他"  # エラー時はデフォルト
 
     def collect_all_events(self):
         """全イベント収集の実行"""

--- a/update_sw_eventlist.py
+++ b/update_sw_eventlist.py
@@ -5,14 +5,13 @@ DoorkeeperとPeatixからStartup Weekendイベント情報を収集し、Google 
 
 import os
 import re
-import json
 import httpx
 import pandas as pd
 import gspread
 from datetime import datetime
 from zoneinfo import ZoneInfo
 from dotenv import load_dotenv
-from typing import List, Dict, Optional, Tuple
+from typing import List, Dict, Optional
 from urllib.parse import urljoin, quote_plus, urlparse, urlunparse
 
 from selenium import webdriver
@@ -206,6 +205,9 @@ class StartupWeekendEventCollector:
                 if self._is_startup_weekend_related(
                     event_title, event_description, organizer_name
                 ):
+                    # イベント種類を判定
+                    event_type = self._determine_event_type(start_date, end_date)
+
                     event_info = {
                         "イベント名": event_title,
                         "開催日": start_date,
@@ -216,6 +218,7 @@ class StartupWeekendEventCollector:
                         "イベントURL": event.get("public_url", ""),
                         "住所": address,
                         "主催者": organizer_name,
+                        "イベント種類": event_type,
                     }
 
                     doorkeeper_events.append(event_info)
@@ -484,15 +487,21 @@ class StartupWeekendEventCollector:
                 "オンライン",
                 "xxxonlineeventxxx",
             ]:
-                event_type = "オンライン"
+                # オンラインイベント
                 location = ""  # Doorkeeperに合わせて空文字列
                 address = ""  # Doorkeeperに合わせて空文字列
                 latitude = ""  # オンラインの場合は緯度経度も空文字列
                 longitude = ""  # オンラインの場合は緯度経度も空文字列
             else:
-                event_type = "物理開催"
+                # 物理開催イベント
                 location = venue_name
                 address = venue_address
+
+            # イベント種類を判定
+            event_type_category = self._determine_event_type(
+                self._format_datetime(start_datetime),
+                self._format_datetime(end_datetime),
+            )
 
             return {
                 "イベント名": event_name,
@@ -504,6 +513,7 @@ class StartupWeekendEventCollector:
                 "イベントURL": self.clean_url(event_url),
                 "住所": address,
                 "主催者": organizer_name,
+                "イベント種類": event_type_category,
             }, "success"
 
         except Exception as e:
@@ -595,6 +605,7 @@ class StartupWeekendEventCollector:
                 "イベントURL": self.clean_url(event_url),
                 "住所": "",
                 "主催者": "",
+                "イベント種類": "本イベント",  # デフォルト値
             }
 
         except Exception as e:
@@ -754,6 +765,23 @@ class StartupWeekendEventCollector:
             print(f"⏱️ 実行完了時間の記録を行いました 実行完了時間: {last_run_time_jst}")
         except Exception as e:
             print(f"❌ Google Sheetsへの保存でエラーが発生しました: {e}")
+
+    def _determine_event_type(self, start_date: str, end_date: str) -> str:
+        """開催日時からイベント種類を判定"""
+        try:
+            if not start_date or not end_date:
+                return "本イベント"  # デフォルト
+
+            # 日付部分のみを比較
+            start_date_only = start_date[:10]  # YYYY-MM-DD
+            end_date_only = end_date[:10]  # YYYY-MM-DD
+
+            if start_date_only == end_date_only:
+                return "プレイベント"  # 同日開催
+            else:
+                return "本イベント"  # 複数日開催
+        except Exception:
+            return "本イベント"  # エラー時はデフォルト
 
     def collect_all_events(self):
         """全イベント収集の実行"""


### PR DESCRIPTION
close #30 

---

This pull request introduces a new feature to classify events by type ("本イベント" or "その他") based on their duration, replacing the previous classification by format ("オンライン" or "物理開催"). It includes updates to the event data processing logic, user interface, and data extraction methods to support this change.

### Updates to event filtering and UI in `streamlit_app.py`:
* Replaced "開催形式" (event format) with "イベント種類" (event type) in the dropdown menu and filtering logic. The new options are "本イベント" (3-day events) and "その他" (non-3-day events). [[1]](diffhunk://#diff-4dc66906e3c3b7f7a82967d85af564f2d5a6e0bee5829aa5eda607dd9756c87dL69-R73) [[2]](diffhunk://#diff-4dc66906e3c3b7f7a82967d85af564f2d5a6e0bee5829aa5eda607dd9756c87dL88-R92) [[3]](diffhunk://#diff-4dc66906e3c3b7f7a82967d85af564f2d5a6e0bee5829aa5eda607dd9756c87dL106-R118)
* Added a new column reference for "イベント種類" in the dataset.

### Enhancements to event data processing in `update_sw_eventlist.py`:
* Introduced a `_determine_event_type` method to classify events as "本イベント" or "その他" based on their start and end dates.
* Updated event data extraction methods to include the "イベント種類" field, using the `_determine_event_type` method for classification. [[1]](diffhunk://#diff-e90be7c753dfcdf485f3ce9da5dca0f5e268390a73f7cb2e1734990812eac15dR208-R210) [[2]](diffhunk://#diff-e90be7c753dfcdf485f3ce9da5dca0f5e268390a73f7cb2e1734990812eac15dR221) [[3]](diffhunk://#diff-e90be7c753dfcdf485f3ce9da5dca0f5e268390a73f7cb2e1734990812eac15dL487-R505) [[4]](diffhunk://#diff-e90be7c753dfcdf485f3ce9da5dca0f5e268390a73f7cb2e1734990812eac15dR516) [[5]](diffhunk://#diff-e90be7c753dfcdf485f3ce9da5dca0f5e268390a73f7cb2e1734990812eac15dR608)

### Code cleanup:
* Removed an unused import of `json` and the `Tuple` type hint from `update_sw_eventlist.py`.