### PR TITLE
stliteをv0.83.0に更新し@stlite/mountableから@stlite/browserに移行

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <title>Startup Weekend Map for Japan</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.73.0/build/stlite.min.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.83.0/build/style.css"
     />
     <link rel="icon" href="assets/icons/favicon.ico" type="image/x-icon" />
     <link rel="manifest" href="assets/icons/site.webmanifest" />
@@ -30,13 +30,15 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.73.0/build/stlite.min.js"></script>
-    <script>
+    <script type="module">
+      import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.83.0/build/stlite.js";
+      
       // 設定：参照先のGoogleスプレッドシートIDとそれぞれGID
       let sheet_id = '1aImknpImJYyDBYcBAbwA0WIck4hmoH1rorRjJftjlj8'
       let sheet_data_gid = '3428216'
       let sheet_last_run_time_gid = '1765691497'
-      stlite.mount(
+      
+      mount(
         {
           requirements: ['pandas', 'streamlit-folium'], // Packages to install
           entrypoint: 'streamlit_app.py', // The target file of the `streamlit run` command
@@ -57,7 +59,7 @@
           },
         },
         document.getElementById('root')
-      )
+      );
     </script>
   </body>
 </html>


### PR DESCRIPTION
## 概要
- stliteライブラリをv0.73.0からv0.83.0に更新
- `@stlite/mountable`から`@stlite/browser`に移行
- ES modulesを使用するようにJavaScriptを更新

## 変更内容
- CSSファイルパス: `@stlite/mountable@0.73.0/build/stlite.min.css` → `@stlite/browser@0.83.0/build/style.css`
- JavaScriptの読み込み方法をES modulesのimport文に変更
- API呼び出しを`stlite.mount()`から`mount()`に変更

## テスト計画
- [x] ローカルでHTTPサーバーを起動してアプリケーションが正常に動作することを確認
- [ ] Streamlitアプリが正しく読み込まれることを確認
- [x] マップ機能が正常に動作することを確認

Fixes #41

🤖 Generated with [Claude Code](https://claude.ai/code)