### PR TITLE
revert: stliteをv0.83.0からv0.73.0に戻す

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <title>Startup Weekend Map for Japan</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.83.0/build/style.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.73.0/build/stlite.min.css"
     />
     <link rel="icon" href="assets/icons/favicon.ico" type="image/x-icon" />
     <link rel="manifest" href="assets/icons/site.webmanifest" />
@@ -30,15 +30,14 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module">
-      import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.83.0/build/stlite.js";
-      
+    <script src="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.73.0/build/stlite.js"></script>
+    <script>
       // 設定：参照先のGoogleスプレッドシートIDとそれぞれGID
       let sheet_id = '1aImknpImJYyDBYcBAbwA0WIck4hmoH1rorRjJftjlj8'
       let sheet_data_gid = '3428216'
       let sheet_last_run_time_gid = '1765691497'
       
-      mount(
+      stlite.mount(
         {
           requirements: ['pandas', 'streamlit-folium'], // Packages to install
           entrypoint: 'streamlit_app.py', // The target file of the `streamlit run` command


### PR DESCRIPTION
## 概要
PR #42 でstliteをv0.83.0にアップデートしましたが、DataFrameの表示に問題が発生したため、安定したv0.73.0に戻します。

## 変更内容
- `@stlite/browser@0.83.0` → `@stlite/mountable@0.73.0`に戻す
- ES modules形式からscript tagによる読み込みに戻す
- `mount()`から`stlite.mount()`に戻す
- CSSファイルパス: `style.css` → `stlite.min.css`に戻す

## 問題
v0.83.0では以下の問題が発生：
- DataFrameが正しく表示されない

## テスト計画
- [x] ローカルでHTTPサーバーを起動してアプリケーションが正常に動作することを確認
- [x] DataFrameが正しく表示されることを確認
- [x] マップ機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)