### PR TITLE
fix: Peatix検索URLを新しいパラメータ形式に更新

### DIFF
--- a/sw_event_collectors/peatix_collector.py
+++ b/sw_event_collectors/peatix_collector.py
@@ -93,9 +93,8 @@ class PeatixCollector(BaseCollector):
 
         while True:
             try:
-                # 元のスクリプトと同じ詳細な検索パラメーターを使用
                 encoded_keyword = quote_plus(keyword)
-                search_url = f"https://peatix.com/search?q={encoded_keyword}&country=JP&l.text=%E3%81%99%E3%81%B9%E3%81%A6%E3%81%AE%E5%A0%B4%E6%89%80&p={page}&size=20&v=3.4&tag_ids=&dr="
+                search_url = f"https://peatix.com/search?q={encoded_keyword}&loc=Anywhere&p={page}"
 
                 print(f"🔍 検索URL: {search_url}")
                 self.driver.get(search_url)


### PR DESCRIPTION
## Summary
- Peatixの検索URLパラメータが変更され、検索結果が0件になっていた問題を修正
- 旧パラメータ (`country=JP`, `l.text=すべての場所`, `size=20`, `v=3.4`, `tag_ids=`, `dr=`) を削除
- 新パラメータ `loc=Anywhere` を使用する形式に更新

**旧URL:**
```
https://peatix.com/search?q={keyword}&country=JP&l.text=すべての場所&p={page}&size=20&v=3.4&tag_ids=&dr=
```

**新URL:**
```
https://peatix.com/search?q={keyword}&loc=Anywhere&p={page}
```

## Test plan
- [ ] `search_url` が新しい形式で出力されることをログで確認
- [ ] 実際にスクリプトを実行し、Startup Weekendイベントが取得できることを確認
- [ ] HTML構造 (`event-list`, `event-thumb_link`) が変わっている場合は追加修正が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)